### PR TITLE
Custom query endpoints feature

### DIFF
--- a/lib/munson/client.rb
+++ b/lib/munson/client.rb
@@ -1,7 +1,7 @@
 module Munson
   class Client
     extend Forwardable
-    def_delegators :query, :include, :sort, :filter, :fields, :fetch, :page, :find
+    def_delegators :query, :include, :sort, :filter, :fields, :fetch, :fetch_from, :page, :find
     def_delegators :connection, :url=, :url, :response_key_format, :response_key_format=
 
     attr_writer :path

--- a/lib/munson/query.rb
+++ b/lib/munson/query.rb
@@ -26,6 +26,20 @@ module Munson
       end
     end
 
+    # Allow fetching from a custom endpoint
+    #
+    # @param [#to_s] path to custom endpoint off of resource
+    # @option [Boolean] collection: true does this endpoint return a collection or a single resource
+    def fetch_from(endpoint, collection: true)
+      if @client
+        path = [@client.agent.negotiate_path, endpoint.gsub(/^\//, '')].join('/')
+        response = @client.agent.get(path: path, params: to_params, headers: @headers)
+        ResponseMapper.new(response.body).send(collection ? :collection : :resource)
+      else
+        raise Munson::ClientNotSet, "Client was not set. Query#new(client)"
+      end
+    end
+
     def find(id)
       if @client
         response = @client.agent.get(id: id, params: to_params, headers: @headers)

--- a/lib/munson/resource.rb
+++ b/lib/munson/resource.rb
@@ -177,7 +177,7 @@ class Munson::Resource
       munson.fields(hash_fields)
     end
 
-    [:include, :sort, :filter, :fetch, :find, :page].each do |method|
+    [:include, :sort, :filter, :fetch, :fetch_from, :find, :page].each do |method|
       class_eval <<-RUBY, __FILE__, __LINE__ + 1
         def #{method}(*args)
           munson.#{method}(*args)

--- a/spec/munson/query_spec.rb
+++ b/spec/munson/query_spec.rb
@@ -29,6 +29,19 @@ describe Munson::Query do
     end
   end
 
+  describe '#fetch_from' do
+    it 'returns a Munson::Collection' do
+      stub_api_request(:albums_top_include_artist)
+
+      client = Munson::Client.new(type: :albums)
+      query   = Munson::Query.new(client)
+      albums  = query.include(:artist).fetch_from('/top')
+
+      expect(albums).to be_a(Munson::Collection)
+      expect(albums.first).to be_a(Album)
+    end
+  end
+
   describe '#to_query_string' do
     describe 'doing all the things' do
       it 'generates a query string' do

--- a/spec/support/macros/stub_request_macros.rb
+++ b/spec/support/macros/stub_request_macros.rb
@@ -14,6 +14,7 @@ module Munson
             album_1: "http://api.example.com/albums/1",
             albums: "http://api.example.com/albums",
             albums_include_artist: "http://api.example.com/albums?include=artist",
+            albums_top_include_artist: "http://api.example.com/albums/top?include=artist",
             album_1_include_artist: "http://api.example.com/albums/1?include=artist",
             album_1_include_songs: "http://api.example.com/albums/1?include=songs",
             articles_include_author: "http://api.example.com/articles?include=author",

--- a/spec/support/responses/albums_top_include_artist.json
+++ b/spec/support/responses/albums_top_include_artist.json
@@ -1,0 +1,80 @@
+{
+  "data": [{
+    "type": "albums",
+    "id": "1",
+    "attributes": {
+      "title": "The Crane Wife"
+    },
+    "links": {
+      "self": "http://api.example.com/albums/1"
+    },
+    "relationships": {
+      "artist": {
+        "data": { "type": "artists", "id": "9" },
+        "links": {
+          "self": "http://api.example.com/albums/1/relationships/artist",
+          "related": "http://api.example.com/albums/1/artist"
+        }
+      }
+    }
+  },{
+    "type": "albums",
+    "id": "2",
+    "attributes": {
+      "title": "Castaways and Cutouts"
+    },
+    "links": {
+      "self": "http://api.example.com/albums/2"
+    },
+    "relationships": {
+      "artist": {
+        "data": { "type": "artists", "id": "9" },
+        "links": {
+          "self": "http://api.example.com/albums/2/relationships/artist",
+          "related": "http://api.example.com/albums/2/artist"
+        }
+      }
+    }
+  },
+  {
+    "type": "albums",
+    "id": "3",
+    "attributes": {
+      "title": "The Mysterious Production of Eggs"
+    },
+    "links": {
+      "self": "http://api.example.com/albums/3"
+    },
+    "relationships": {
+      "artist": {
+        "data": { "type": "artists", "id": "10" },
+        "links": {
+          "self": "http://api.example.com/albums/3/relationships/artist",
+          "related": "http://api.example.com/albums/3/artist"
+        }
+      }
+    }
+  }],
+  "included": [{
+    "type": "artists",
+    "id": "9",
+    "attributes": {
+      "name": "The Decemberists",
+      "twitter": "@TheDecemberists"
+    },
+    "links": {
+      "self": "http://example.com/artist/9"
+    }
+  },
+  {
+    "type": "artists",
+    "id": "10",
+    "attributes": {
+      "name": "Andrew Bird",
+      "twitter": "@andrewbird"
+    },
+    "links": {
+      "self": "http://example.com/artist/10"
+    }
+  }]
+}


### PR DESCRIPTION
Adding the ability to specify custom endpoints (still {json:api}) via `Query#fetch_from()`.

The test I added defines a custom endpoint at `GET /albums/top` which might return only the top X number of albums, functioning otherwise like `GET /albums` as a convenience endpoint for some complicated set of filters and paging.

This can now be done via `Album.fetch_from('/top')`. Most of the logic for this method is taken directly from `Query#fetch()`. `Query#fetch_from()` also supports a boolean option (`collection`) to specify if the custom endpoint returns a collection or a resource.

All previously passing tests still pass, and I have added a new test for this additional method.