### PR TITLE
Require date at the top of Munson::Attribute

### DIFF
--- a/lib/munson/attribute.rb
+++ b/lib/munson/attribute.rb
@@ -1,3 +1,5 @@
+require 'date'
+
 module Munson
   class Attribute
     attr_reader :name


### PR DESCRIPTION
You forgot to require `date` which causes a little inconvenience in here:
/lib/munson/attribute.rb:42:in `cast_value': uninitialized constant Munson::Attribute::Date (NameError)

In this pull request you can find a small improvement from me 👍 